### PR TITLE
feat: 지역 선택 버튼 클릭 시 폼 데이터 유지 및 라우팅 처리 추가

### DIFF
--- a/boardgame-frontend/package.json
+++ b/boardgame-frontend/package.json
@@ -12,7 +12,8 @@
     "next": "16.0.1",
     "next-auth": "5.0.0-beta.30",
     "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "react-hook-form": "^7.66.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/boardgame-frontend/pnpm-lock.yaml
+++ b/boardgame-frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      react-hook-form:
+        specifier: ^7.66.1
+        version: 7.66.1(react@19.2.0)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -1679,6 +1682,12 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-hook-form@7.66.1:
+    resolution: {integrity: sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3691,6 +3700,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-hook-form@7.66.1(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   react-is@16.13.1: {}
 

--- a/boardgame-frontend/src/app/signup/page.tsx
+++ b/boardgame-frontend/src/app/signup/page.tsx
@@ -1,49 +1,18 @@
-import Button from "@/components/common/Button";
-import TextInput from "@/components/common/TextInput";
-import GenderRadio from "@/components/signup/GenderRadio";
 import Image from "next/image";
 import Link from "next/link";
+import { SearchParams } from "next/dist/server/request/search-params";
+import SignupForm from "@/components/signup/SignupForm";
+import { SearchFormValueType } from "@/types/SearchFormValueType";
 
-export default function Signup() {
+export default async function Signup({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const { nickname = "", gender = "", location = "" }: SearchFormValueType = await searchParams;
+
   return (
     <>
       <Link className="w-fit" href="/login">
         <Image src="/icons/ic_close.svg" alt="닫기 버튼" width={24} height={24} />
       </Link>
-
-      <form className="flex flex-col justify-between flex-1">
-        <div>
-        <h2 className="mt-4 mb-10 font-semibold text-2xl text-[#161616]">회원 정보를 입력해주세요</h2>
-          <fieldset>
-          <TextInput label="닉네임" name="nickname" placeholder="닉네임을 입력해주세요" />
-            <div className="flex items-center gap-1 mt-2">
-              <Image src="/icons/ic_information.svg" alt="" width={16} height={16} />
-              <span className="text-[13px] text-[#999999]">특수기호를 제외한 한글 또는 영문을 입력해주세요</span>
-            </div>
-          </fieldset>
-
-          <fieldset className="w-full mt-8">
-            <legend className="text-sm font-medium text-[#363636]">성별</legend>
-            <div className="flex gap-2 mt-3 ">
-              <GenderRadio id="man" name="gender" value="M" label="남성" />
-              <GenderRadio id="female" name="gender" value="F" label="여성" />
-            </div>
-          </fieldset>
-
-          <fieldset className="mt-8">
-            <legend className="block font-medium text-sm text-[#363636]">지역</legend>
-            <Link
-              className="flex items-center justify-between mt-3 text-sm text-[#767676] border border-[#E9E9ED] rounded-xl py-3.5 pl-3 pr-3.5"
-              href="/signup/location"
-            >
-              활동 지역을 선택해주세요
-              <Image src="/icons/ic_chevron_right_icon.svg" alt="" width={20} height={20} />
-            </Link>
-          </fieldset>
-        </div>
-
-        <Button type="submit" text="다음" btnSize="large" />
-      </form>
+      <SignupForm nickname={nickname} gender={gender} location={location} />
     </>
   );
 }

--- a/boardgame-frontend/src/components/common/Button.tsx
+++ b/boardgame-frontend/src/components/common/Button.tsx
@@ -7,6 +7,7 @@ interface ButtonType {
   outline?: "default" | "selected";
   bgColor?: string;
   textColor?: string;
+  fontWeight?: string;
   icon?: React.ReactNode;
   gap?: string;
   handleSubmit?: () => void;
@@ -21,6 +22,7 @@ export default function Button({
   outline,
   bgColor = "bg-[#EEF0F7]",
   textColor = "text-[#767676]",
+  fontWeight = "font-semibold",
   icon,
   gap = "gap-[4px]",
   onClick,
@@ -38,7 +40,7 @@ export default function Button({
   return (
     <button
       type={type}
-      className={`flex justify-center ${btnResultSize} ${outlineResult} ${gap} rounded-lg ${bgColor} ${btnSize} font-semibold ${textColor} cursor-pointer`}
+      className={`flex justify-center w-full ${btnResultSize} ${outlineResult} ${gap} rounded-lg ${bgColor} ${btnSize} ${fontWeight} ${textColor} cursor-pointer`}
       onClick={onClick}
       disabled={disabled}
     >

--- a/boardgame-frontend/src/components/common/Button.tsx
+++ b/boardgame-frontend/src/components/common/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonType {
   gap?: string;
   handleSubmit?: () => void;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 export default function Button({
@@ -23,6 +24,7 @@ export default function Button({
   icon,
   gap = "gap-[4px]",
   onClick,
+  disabled,
 }: ButtonType) {
   const mediumSize = "py-3.5 text-sm"; //14px 14px
   const largeSize = "py-4 text-base"; //16px 16px
@@ -38,6 +40,7 @@ export default function Button({
       type={type}
       className={`flex justify-center ${btnResultSize} ${outlineResult} ${gap} rounded-lg ${bgColor} ${btnSize} font-semibold ${textColor} cursor-pointer`}
       onClick={onClick}
+      disabled={disabled}
     >
       {icon}
       {text}

--- a/boardgame-frontend/src/components/signup/GenderRadio.tsx
+++ b/boardgame-frontend/src/components/signup/GenderRadio.tsx
@@ -1,17 +1,18 @@
-export default function GenderRadio({
-  id,
-  name,
-  value,
-  label,
-}: {
+import { forwardRef } from "react";
+
+interface GenderRadioProps {
   id: string;
-  name: string;
-  value: string;
   label: string;
-}) {
+  value: "male" | "female";
+}
+
+const GenderRadio = forwardRef<HTMLInputElement, GenderRadioProps>(function GenderRadio(
+  { id, label, value, ...rest },
+  ref
+) {
   return (
     <div className="flex-1">
-      <input className="peer sr-only" type="radio" id={id} name={name} value={value} />
+      <input className="peer sr-only" type="radio" id={id} value={value} {...rest} ref={ref} />
       <label
         className="block w-full py-3.5 border border-[#E9E9ED] rounded-xl peer-checked:border-[#161616] cursor-pointer text-center text-sm text-[#161616] font-medium"
         htmlFor={id}
@@ -20,4 +21,6 @@ export default function GenderRadio({
       </label>
     </div>
   );
-}
+});
+
+export default GenderRadio;

--- a/boardgame-frontend/src/components/signup/SignupForm.tsx
+++ b/boardgame-frontend/src/components/signup/SignupForm.tsx
@@ -3,11 +3,11 @@
 import TextInput from "@/components/common/TextInput";
 import Image from "next/image";
 import GenderRadio from "@/components/signup/GenderRadio";
-import Link from "next/link";
 import Button from "@/components/common/Button";
 import { useForm } from "react-hook-form";
 import { SearchFormValueType } from "@/types/SearchFormValueType";
 import { useRouter } from "next/navigation";
+import React from "react";
 
 export default function SignupForm({ nickname, gender, location }: SearchFormValueType) {
   const router = useRouter();
@@ -16,6 +16,7 @@ export default function SignupForm({ nickname, gender, location }: SearchFormVal
     register,
     handleSubmit,
     formState: { errors, isValid },
+    getValues,
   } = useForm<SearchFormValueType>({
     defaultValues: {
       nickname: nickname,
@@ -29,6 +30,17 @@ export default function SignupForm({ nickname, gender, location }: SearchFormVal
     const filteredData = Object.entries(data).filter(([_, v]) => v);
     const params = new URLSearchParams(filteredData);
     router.push(`/agreement?${params.toString()}`);
+  };
+
+  const handleLocationClick = () => {
+    const currentFormData = getValues();
+    const params = new URLSearchParams({
+      nickname: currentFormData.nickname || "",
+      gender: currentFormData.gender || "",
+      location: currentFormData.location || "",
+    });
+
+    router.push(`/signup/location?${params.toString()}`);
   };
 
   return (
@@ -91,13 +103,19 @@ export default function SignupForm({ nickname, gender, location }: SearchFormVal
 
         <fieldset className="mt-8">
           <legend className="block font-medium text-sm text-[#363636]">지역</legend>
-          <Link
-            className="flex items-center justify-between mt-3 text-sm text-[#767676] border border-[#E9E9ED] rounded-xl py-3.5 pl-3 pr-3.5"
-            href="/signup/location"
+          <button
+            type="button"
+            className={`flex ${location ? "justify-center" : "justify-between"} w-full mt-3 text-sm text-[${location ? "#161616" : "#767676"}] border border-[${location ? "#161616" : "#E9E9ED"}] rounded-xl py-3.5 pl-3 pr-3.5`}
+            onClick={handleLocationClick}
+            {...register("location", { required: true })}
           >
-            활동 지역을 선택해주세요
-            <Image src="/icons/ic_chevron_right_icon.svg" alt="" width={20} height={20} />
-          </Link>
+            {location || (
+              <>
+                활동 지역을 선택해주세요
+                <Image src="/icons/ic_chevron_right_icon.svg" alt="" width={20} height={20} />
+              </>
+            )}
+          </button>
         </fieldset>
       </div>
 

--- a/boardgame-frontend/src/components/signup/SignupForm.tsx
+++ b/boardgame-frontend/src/components/signup/SignupForm.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import TextInput from "@/components/common/TextInput";
+import Image from "next/image";
+import GenderRadio from "@/components/signup/GenderRadio";
+import Link from "next/link";
+import Button from "@/components/common/Button";
+import { useForm } from "react-hook-form";
+import { SearchFormValueType } from "@/types/SearchFormValueType";
+import { useRouter } from "next/navigation";
+
+export default function SignupForm({ nickname, gender, location }: SearchFormValueType) {
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<SearchFormValueType>({
+    defaultValues: {
+      nickname: nickname,
+      gender: gender,
+      location: location,
+    },
+    mode: "onChange",
+  });
+
+  const onSubmit = (data: SearchFormValueType) => {
+    const filteredData = Object.entries(data).filter(([_, v]) => v);
+    const params = new URLSearchParams(filteredData);
+    router.push(`/agreement?${params.toString()}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col justify-between flex-1">
+      <div>
+        <h2 className="mt-4 mb-10 font-semibold text-2xl text-[#161616]">회원 정보를 입력해주세요</h2>
+        <fieldset>
+          <TextInput
+            label="닉네임"
+            placeholder="닉네임을 입력해주세요"
+            {...register("nickname", {
+              required: true,
+              pattern: {
+                value: /^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z]+$/,
+                message: "특수기호를 제외한 한글 또는 영문을 입력해주세요",
+              },
+            })}
+          />
+          <div className="flex items-center gap-1 mt-2">
+            <svg
+              className={`${!errors.nickname?.message ? "text-[#999999]" : "text-[#FC3B45]"}`}
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect x="1.5" y="1.5" width="13" height="13" rx="6.5" stroke="currentColor" />
+              <circle cx="8" cy="5" r="0.75" fill="currentColor" />
+              <path d="M8 7.5V11.5" stroke="currentColor" strokeLinecap="round" />
+            </svg>
+
+            <span className={`text-[13px] ${!errors.nickname?.message ? "text-[#999999]" : "text-[#FC3B45]"}`}>
+              특수기호를 제외한 한글 또는 영문을 입력해주세요
+            </span>
+          </div>
+        </fieldset>
+
+        <fieldset className="w-full mt-8">
+          <legend className="text-sm font-medium text-[#363636]">성별</legend>
+          <div className="flex gap-2 mt-3 ">
+            <GenderRadio
+              id="man"
+              label="남성"
+              value="male"
+              {...register("gender", {
+                required: true,
+              })}
+            />
+            <GenderRadio
+              id="female"
+              label="여성"
+              value="female"
+              {...register("gender", {
+                required: true,
+              })}
+            />
+          </div>
+        </fieldset>
+
+        <fieldset className="mt-8">
+          <legend className="block font-medium text-sm text-[#363636]">지역</legend>
+          <Link
+            className="flex items-center justify-between mt-3 text-sm text-[#767676] border border-[#E9E9ED] rounded-xl py-3.5 pl-3 pr-3.5"
+            href="/signup/location"
+          >
+            활동 지역을 선택해주세요
+            <Image src="/icons/ic_chevron_right_icon.svg" alt="" width={20} height={20} />
+          </Link>
+        </fieldset>
+      </div>
+
+      <Button
+        type="submit"
+        text="다음"
+        btnSize="large"
+        textColor={`${!isValid ? "text-[#767676]" : "#161616"}`}
+        bgColor={`${!isValid ? "bg-[#EEF0F7]" : "bg-[#06E393]"}`}
+        disabled={!isValid}
+      />
+    </form>
+  );
+}

--- a/boardgame-frontend/src/types/SearchFormValueType.ts
+++ b/boardgame-frontend/src/types/SearchFormValueType.ts
@@ -1,0 +1,5 @@
+export interface SearchFormValueType {
+  nickname?: string;
+  gender?: string;
+  location?: string;
+}


### PR DESCRIPTION
### 🔖 제목

-   feat: 지역 선택 버튼 클릭 시 폼 데이터 유지 및 라우팅 처리 추가

---

### 📄 본문

-   지역 선택 버튼 클릭시 폼데이터 전달 로직 추가
-   공통 버튼 컴포넌트 w-full 추가 및 fontWeight를 props로 받도록 수정

---

### 🔗 관련 이슈

    -   `Closes #18`
    -   `Related to #18`

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
