### PR TITLE
feat/메인 페이지 마크업 및 컴포넌트 정의

### DIFF
--- a/boardgame-frontend/src/app/board/new/page.tsx
+++ b/boardgame-frontend/src/app/board/new/page.tsx
@@ -1,0 +1,5 @@
+export default function New (){
+  return(
+    <div></div>
+  )
+}

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -1,7 +1,28 @@
+import Header from "@/components/common/Header";
+import Banner from "@/components/common/Banner";
+import Calendar from "@/components/common/Calendar";
+import CardList from "@/components/common/CardList";
+import Link from "next/link";
+
+
 export default function Home() {
   return (
     <div>
-        <h1>메인 페이지</h1>
+        
+
+          <Header/>
+          <main>
+            <section>
+              <Banner/>
+            </section>
+            <section>
+              <Calendar/>
+            </section>
+            <section>
+              <CardList/>
+            </section>
+            <Link href="/board/new">+ 모임만들기</Link>
+          </main>
     </div>
   );
 }

--- a/boardgame-frontend/src/components/common/Banner.tsx
+++ b/boardgame-frontend/src/components/common/Banner.tsx
@@ -1,0 +1,5 @@
+export default  function Banner () {
+  return <div>
+    banner
+  </div>
+}

--- a/boardgame-frontend/src/components/common/Calendar.tsx
+++ b/boardgame-frontend/src/components/common/Calendar.tsx
@@ -1,0 +1,7 @@
+export default function Calendar (){
+  return (
+    <div>
+      Calendar
+    </div>
+  )
+}

--- a/boardgame-frontend/src/components/common/Card.tsx
+++ b/boardgame-frontend/src/components/common/Card.tsx
@@ -1,0 +1,5 @@
+export default function Card (){
+  return(
+    <div>Card</div>
+  )
+}

--- a/boardgame-frontend/src/components/common/CardList.tsx
+++ b/boardgame-frontend/src/components/common/CardList.tsx
@@ -1,0 +1,11 @@
+import Card from "./Card"
+
+export default function CardList (){
+  return (
+    <div>
+      <ul>
+        <Card/>
+      </ul>
+    </div>
+  )
+}

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -1,0 +1,4 @@
+export default function Header (){
+  return<>
+  <h1 className="sr-only">보드게임 친구 찾을때 보드메이트!</h1></>
+}


### PR DESCRIPTION
### 🔖 제목

-   커밋 메시지와 동일한 형식을 사용합니다.  
feat: 메인 페이지 마크업 및 컴포넌트 정의


---

### 📄 본문

메인 페이지 작업을 위한 마크업과 컴포넌트 분리


---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #21 `
    -   `Related to #21 `

---

### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.
-   [✅] 관련 이슈를 연결했습니다.
