### PR TITLE
refactor: 회원가입시 페이지간 데이터 공유를 session으로 변경(추후 zustand로 변경 예정)

### DIFF
--- a/boardgame-frontend/src/app/signup/page.tsx
+++ b/boardgame-frontend/src/app/signup/page.tsx
@@ -1,18 +1,14 @@
 import Image from "next/image";
 import Link from "next/link";
-import { SearchParams } from "next/dist/server/request/search-params";
 import SignupForm from "@/components/signup/SignupForm";
-import { SearchFormValueType } from "@/types/SearchFormValueType";
 
-export default async function Signup({ searchParams }: { searchParams: Promise<SearchParams> }) {
-  const { nickname = "", gender = "", location = "" }: SearchFormValueType = await searchParams;
-
+export default async function Signup() {
   return (
     <>
       <Link className="w-fit" href="/login">
         <Image src="/icons/ic_close.svg" alt="닫기 버튼" width={24} height={24} />
       </Link>
-      <SignupForm nickname={nickname} gender={gender} location={location} />
+      <SignupForm />
     </>
   );
 }

--- a/boardgame-frontend/src/app/signup/page.tsx
+++ b/boardgame-frontend/src/app/signup/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import SignupForm from "@/components/signup/SignupForm";
 
-export default async function Signup() {
+export default function Signup() {
   return (
     <>
       <Link className="w-fit" href="/login">

--- a/boardgame-frontend/src/components/signup/SignupForm.tsx
+++ b/boardgame-frontend/src/components/signup/SignupForm.tsx
@@ -5,11 +5,18 @@ import Image from "next/image";
 import GenderRadio from "@/components/signup/GenderRadio";
 import Button from "@/components/common/Button";
 import { useForm } from "react-hook-form";
-import { SearchFormValueType } from "@/types/SearchFormValueType";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getSessionValue } from "@/util/getSession";
 
-export default function SignupForm({ nickname, gender, location }: SearchFormValueType) {
+interface SearchFormValueType {
+  nickname?: string;
+  gender?: string;
+  location?: string;
+}
+
+export default function SignupForm() {
+  const [location, setLocation] = useState("");
   const router = useRouter();
 
   const {
@@ -19,29 +26,37 @@ export default function SignupForm({ nickname, gender, location }: SearchFormVal
     getValues,
   } = useForm<SearchFormValueType>({
     defaultValues: {
-      nickname: nickname,
-      gender: gender,
-      location: location,
+      nickname: getSessionValue("nickname") || "",
+      gender: getSessionValue("gender") || "",
+      location: getSessionValue("location") || "",
     },
     mode: "onChange",
   });
 
-  const onSubmit = (data: SearchFormValueType) => {
-    const filteredData = Object.entries(data).filter(([_, v]) => v);
-    const params = new URLSearchParams(filteredData);
-    router.push(`/agreement?${params.toString()}`);
+  const saveFormDataToSession = () => {
+    const { nickname = "", gender = "", location = "" } = getValues();
+
+    sessionStorage.setItem("nickname", nickname);
+    sessionStorage.setItem("gender", gender);
+    sessionStorage.setItem("location", location);
+  };
+
+  const onSubmit = () => {
+    saveFormDataToSession();
+
+    router.push(`/agreement`);
   };
 
   const handleLocationClick = () => {
-    const currentFormData = getValues();
-    const params = new URLSearchParams({
-      nickname: currentFormData.nickname || "",
-      gender: currentFormData.gender || "",
-      location: currentFormData.location || "",
-    });
+    saveFormDataToSession();
 
-    router.push(`/signup/location?${params.toString()}`);
+    router.push("/signup/location");
   };
+
+  useEffect(() => {
+    //TODO: 임시코드이며 추후 session에서 zustand로 변경 예정
+    Promise.resolve(getSessionValue("location")).then((data) => setLocation(data));
+  }, []);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col justify-between flex-1">

--- a/boardgame-frontend/src/types/SearchFormValueType.ts
+++ b/boardgame-frontend/src/types/SearchFormValueType.ts
@@ -1,5 +1,0 @@
-export interface SearchFormValueType {
-  nickname?: string;
-  gender?: string;
-  location?: string;
-}

--- a/boardgame-frontend/src/util/getSession.ts
+++ b/boardgame-frontend/src/util/getSession.ts
@@ -1,0 +1,4 @@
+export function getSessionValue(key: string) {
+  if (typeof window === "undefined") return "";
+  return sessionStorage.getItem(key) || "";
+}


### PR DESCRIPTION
### 🔖 제목

-   refactor: 회원가입시 페이지간 데이터 공유를 session으로 변경(추후 zustand로 변경 예정)

---

### 📄 본문

<img width="1853" height="923" alt="image" src="https://github.com/user-attachments/assets/dbe4abf8-4b9c-4c17-9de6-3bf9aebf4fb2" />

-   formData로 데이터 공유 => session으로 변경(추후 zustand로 변경 예정)

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #28`
    -   `Related to #28`

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
