### PR TITLE
feat: BottomSheet 레이아웃 설정

### DIFF
--- a/boardgame-frontend/src/app/board/new/page.tsx
+++ b/boardgame-frontend/src/app/board/new/page.tsx
@@ -20,7 +20,7 @@ export default function New() {
   const [people, setPeople] = useState<number | "무제한">(2);
 
   return (
-    <div className="flex justify-center">
+    <div id="page-container" className="flex justify-center relative">
       <div className="w-[335px] flex flex-col">
         <header className="h-[52px] py-3 flex gap-0.5 items-center">
           <Link href="/login">
@@ -54,10 +54,10 @@ export default function New() {
               <span className="font-medium text-[14px] text-[#999999]">(선택)</span>
             </div>
 
-            <div className="min-w-[335px] h-10 rounded-lg border border-[#DEE1E6] p-3 flex justify-between items-center">
+            <button className="min-w-[335px] h-10 rounded-lg border border-[#DEE1E6] p-3 flex justify-between items-center">
               <span className="font-normal text-sm text-[#767676]">원하는 게임을 지정해주세요(최대 3개)</span>
               <Image src={nextIcon} alt="" width={20} height={20} />
-            </div>
+            </button>
           </div>
 
           {/* 장소 지정 */}

--- a/boardgame-frontend/src/app/layout.tsx
+++ b/boardgame-frontend/src/app/layout.tsx
@@ -10,8 +10,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>
-        <Providers>{children}</Providers>
+      <body className="flex justify-center">
+        <Providers>
+          <div className="w-[375px]">{children}</div>
+        </Providers>
       </body>
     </html>
   );

--- a/boardgame-frontend/src/app/layout.tsx
+++ b/boardgame-frontend/src/app/layout.tsx
@@ -13,8 +13,12 @@ export default function RootLayout({
     <html lang="ko">
       <body className="flex justify-center">
         <Providers>
-          <div className="w-[375px]">{children}</div>
-          <BottomSheet />
+          <div className="w-[375px] relative">
+            <div className="w-full">
+              {children}
+              <BottomSheet />
+            </div>
+          </div>
         </Providers>
       </body>
     </html>

--- a/boardgame-frontend/src/app/layout.tsx
+++ b/boardgame-frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 
 import React from "react";
 import Providers from "@/components/Providers";
+import BottomSheet from "@/components/common/BottomSheet";
 
 export default function RootLayout({
   children,
@@ -13,6 +14,7 @@ export default function RootLayout({
       <body className="flex justify-center">
         <Providers>
           <div className="w-[375px]">{children}</div>
+          <BottomSheet />
         </Providers>
       </body>
     </html>

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -13,7 +13,7 @@ import React from "react";
 export default function Home() {
   return (
     <div className="flex justify-center">
-      <div className="w-[375px] min-h-screen flex flex-col items-center bg-[#F5F6FA] relative">
+      <div className="w-full min-h-screen flex flex-col items-center bg-[#F5F6FA] relative">
         <Header />
         <main>
           <section className="w-full flex flex-col items-center">

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import Image from "next/image";
 import bottomLogo from "../../public/bottomLogo.svg";
 import plusIcon from "../../public/icons/ic_plus.svg";
-import BottomSheet from "@/components/common/BottomSheet";
 import React from "react";
 
 export default function Home() {
@@ -34,7 +33,6 @@ export default function Home() {
               className="mt-6 mb-[60px]"
             />
           </div>
-          <BottomSheet />
         </main>
         <Link href="/board/new">
           <div className="fixed bottom-10 right-[max(20px,calc(50%-167.5px))] w-[123px] h-12 rounded-[40px] py-3 pl-3 pr-4 bg-[#06E393] shadow-[0px_4px_16px_0px_#00000040]">

--- a/boardgame-frontend/src/components/common/BottomSheet.tsx
+++ b/boardgame-frontend/src/components/common/BottomSheet.tsx
@@ -4,5 +4,21 @@ import useBottomSheetStore from "@/stores/useBottomSheetStore";
 
 export default function BottomSheet() {
   const { isOpen, children } = useBottomSheetStore();
-  return <div className="p-5 absolute bottom-0">{isOpen && children}</div>;
+
+  return (
+    <>
+      <div
+        className={`absolute inset-0 bg-[#00000066] transition-opacity duration-400 ${
+          isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+      />
+      <div
+        className={`w-full p-5 absolute bottom-0 h-5/6 bg-white rounded-t-2xl overflow-y-auto transition-transform duration-400 ${
+          isOpen ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        {children}
+      </div>
+    </>
+  );
 }

--- a/boardgame-frontend/src/components/login/Signin.tsx
+++ b/boardgame-frontend/src/components/login/Signin.tsx
@@ -14,7 +14,7 @@ export default function Signin() {
 
   return (
     <main className="min-h-screen flex flex-col items-center justify-center gap-6">
-      <section className="w-full max-w-[375px] h-[524px] flex flex-col gap-6 items-center justify-center">
+      <section className="w-full h-[524px] flex flex-col gap-6 items-center justify-center">
         {/* 말풍선 */}
         <div className="flex flex-col items-center">
           <div className="w-[118px] h-[52px] rounded-xl px-3 py-2 bg-[#161616]">


### PR DESCRIPTION
### 🔖 제목

-   feat: BottomSheet 레이아웃 설정

---

### 📄 본문

-   최상위 레이아웃 375px로 고정하였고 페이지 별로 375px로 잡혀있던건 w-full로 수정하였음
-   BottomSheet을 최상위에 위치시켰고 공통 레이아웃 및 애니메이션 설정해놨음

---

### 🔗 관련 이슈

-   `Closes #62`
-   `Related to #62`

---

### ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다.
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [ ] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
