### PR TITLE
feat: 회원가입 완료시 next-auth 세션 업데이트 로직 추가

### DIFF
--- a/boardgame-frontend/src/app/agreement/page.tsx
+++ b/boardgame-frontend/src/app/agreement/page.tsx
@@ -119,8 +119,8 @@ export default function Agreement() {
       sessionStorage.removeItem("gender");
       sessionStorage.removeItem("region");
 
-      // 세션 갱신
-      await update();
+      // profileCompleted 값을 true로 session 갱신
+      await update({ profileCompleted: true });
 
       // 가입 완료 후 홈으로 이동
       router.push("/");

--- a/boardgame-frontend/src/auth.ts
+++ b/boardgame-frontend/src/auth.ts
@@ -14,7 +14,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
-    async jwt({ token, account, profile, user }) {
+    async jwt({ token, account, profile, user, trigger, session }) {
+      // 세션 업데이트 시 (회원가입 완료 후 등)
+      if (trigger === "update" && session) {
+        if (session.profileCompleted !== undefined) {
+          token.profileCompleted = session.profileCompleted;
+        }
+        return token;
+      }
+
       if (account?.provider === "kakao" && profile) {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/auth/sync-from-nextauth`, {
           method: "POST",


### PR DESCRIPTION
### 🔖 제목

-   feat: 회원가입 완료시 next-auth 세션 업데이트 로직 추가

---

### 📄 본문

-  회원가입 완료시 next-auth 세션 업데이트 로직 추가

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #65`
    -   `Related to #65`

---

### ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다.
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [ ] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
