### PR TITLE
46 refactor textinput styling

### DIFF
--- a/boardgame-frontend/src/components/common/TextInput.tsx
+++ b/boardgame-frontend/src/components/common/TextInput.tsx
@@ -14,7 +14,7 @@ function TextInput(
   ref: React.ForwardedRef<HTMLInputElement>
 ) {
   return (
-    <div className="mt-[40px] text-sm flex flex-col">
+    <div className="text-sm flex flex-col">
       <label htmlFor={name} className={isHidden ? "sr-only" : ""}>
         {label}
       </label>

--- a/boardgame-frontend/src/components/common/TextInput.tsx
+++ b/boardgame-frontend/src/components/common/TextInput.tsx
@@ -21,7 +21,7 @@ function TextInput(
       <input
         name={name}
         id={name}
-        className="my-[12px] p-3 border rounded-xl border-[#161616] outline-none"
+        className="my-[12px] p-3 border rounded-xl border-[#E9E9ED] outline-none focus:border-[#161616] [&:not(:placeholder-shown)]:border-[#161616]"
         placeholder={placeholder}
         type="text"
         maxLength={10}

--- a/boardgame-frontend/src/components/signup/LocationSearchResults.tsx
+++ b/boardgame-frontend/src/components/signup/LocationSearchResults.tsx
@@ -31,7 +31,7 @@ export default function LocationSearchResults({ results, onSelect, isLoading }: 
               <button
                 type="button"
                 onClick={() => onSelect(locationString)}
-                className="w-full text-left hover:text-[#06E393] transition-colors"
+                className="w-full text-left transition-colors cursor-pointer"
               >
                 {locationString}
               </button>

--- a/boardgame-frontend/src/components/signup/SignupLocationForm.tsx
+++ b/boardgame-frontend/src/components/signup/SignupLocationForm.tsx
@@ -45,7 +45,7 @@ export default function SignupLocationForm() {
       </Link>
 
       <div className="flex flex-col">
-        <h2 className="mt-4 font-semibold text-2xl text-[#161616]">활동 지역을 선택해주세요</h2>
+        <h2 className="mt-4 mb-[40px]  font-semibold text-2xl text-[#161616]">활동 지역을 선택해주세요</h2>
 
         <TextInput
           label="활동지역"


### PR DESCRIPTION
### 🔖 제목

- TextInput 컴포넌트 스타일링 추가 및 수정

---

### 📄 본문

- focus돼있거나, placeholder가 보이지 않을 때, border에 색깔이 #161616 / 그 외의 상황에선 #E9E9ED
- TextInput 컴포넌트의 margin-top값을 레이아웃 파일로 옮김

![화면 기록 2025-12-03 오전 11 28 19](https://github.com/user-attachments/assets/7810ff5e-f790-4f60-8980-ce1732debcff)

### 🔗 관련 이슈

    -   `Closes #46`
    -   `Related to #46`

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
