### PR TITLE
70 feature 날짜 선택 바텀 시트 구현

### DIFF
--- a/boardgame-frontend/public/icons/ic_right.svg
+++ b/boardgame-frontend/public/icons/ic_right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 18L15 12L9 6" stroke="#363636" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/boardgame-frontend/src/app/board/new/page.tsx
+++ b/boardgame-frontend/src/app/board/new/page.tsx
@@ -10,6 +10,8 @@ import { ChangeEvent, useState } from "react";
 import PeopleSelector from "@/components/common/PeopleSelector";
 import useBottomSheetStore from "@/stores/useBottomSheetStore";
 import GameSelect from "@/components/bottom-sheet/GameSelect";
+import DateSelector from "@/components/bottom-sheet/DateSelector";
+import useDateStore from "@/stores/useDateStore";
 
 export default function New() {
   // textarea 글자수 카운터
@@ -21,9 +23,14 @@ export default function New() {
   //인원수
   const [people, setPeople] = useState<number | "무제한">(2);
   const { setOpen } = useBottomSheetStore();
+  const { selectedDate } = useDateStore();
 
   const handleGameSelect = () => {
-    setOpen(<GameSelect />);
+    setOpen(<GameSelect />, "fixed");
+  };
+
+  const handleDateSelect = () => {
+    setOpen(<DateSelector />, "auto");
   };
 
   return (
@@ -63,6 +70,7 @@ export default function New() {
 
             <button
               className="min-w-[335px] h-10 rounded-lg border border-[#DEE1E6] p-3 flex justify-between items-center cursor-pointer"
+              type="button"
               onClick={handleGameSelect}
             >
               <span className="font-normal text-sm text-[#767676]">원하는 게임을 지정해주세요(최대 3개)</span>
@@ -84,10 +92,16 @@ export default function New() {
           <div className="mt-8 flex flex-col gap-2">
             <h3 className="font-medium text-[14px] text-[#363636]">날짜</h3>
 
-            <div className="min-w-[335px] h-10 rounded-lg border border-[#DEE1E6] p-3 flex justify-between items-center">
-              <span className="font-normal text-sm text-[#767676]">25.11.27</span>
+            <button
+              className="min-w-[335px] h-10 rounded-lg border border-[#DEE1E6] p-3 flex justify-between items-center"
+              type="button"
+              onClick={handleDateSelect}
+            >
+              <span className="font-normal text-sm text-[#767676]">
+                {selectedDate ? selectedDate.toLocaleDateString() : "날짜를 선택해주세요."}
+              </span>
               <Image src={calendarIcon} alt="" width={20} height={20} />
-            </div>
+            </button>
           </div>
 
           {/* 인원 지정 */}

--- a/boardgame-frontend/src/app/layout.tsx
+++ b/boardgame-frontend/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className="flex justify-center">
         <Providers>
-          <div className="w-[375px] relative">
+          <div className="w-[375px] min-h-dvh relative overflow-hidden">
             <div className="w-full">
               {children}
               <BottomSheet />

--- a/boardgame-frontend/src/components/bottom-sheet/DateSelector.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/DateSelector.tsx
@@ -1,0 +1,194 @@
+"use client";
+import Button from "../common/Button";
+import iconClose from "../../../public/icons/ic_close_gray.svg";
+import leftIcon from "../../../public/icons/ic_back.svg";
+import rightButton from "../../../public/icons/ic_right.svg";
+import { useState } from "react";
+
+import Image from "next/image";
+import useBottomSheetStore from "@/stores/useBottomSheetStore";
+import useDateStore from "@/stores/useDateStore";
+
+export default function DateSelector() {
+  const { setClose } = useBottomSheetStore();
+  const { setSelectedDate: saveSelectedDate } = useDateStore();
+
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const today = new Date();
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // 이번 달인지 확인 (이전 달 버튼 비활성화용)
+  const isCurrentMonthView = year === today.getFullYear() && month === today.getMonth();
+
+  // 3개월 후 날짜 계산 (다음 달 버튼 비활성화용)
+  const maxDate = new Date(today.getFullYear(), today.getMonth() + 3, 1);
+  const isMaxMonth = year === maxDate.getFullYear() && month === maxDate.getMonth();
+
+  // 현재 달의 첫 날
+  const firstDayOfMonth = new Date(year, month, 1);
+  // 달력 시작 날짜를 현재 달의 첫 날의 주의 일요일로 설정
+  const startDay = new Date(firstDayOfMonth);
+  startDay.setDate(1 - firstDayOfMonth.getDay());
+
+  // 현재 달의 마지막 날
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+  // 달력 끝 날짜를 현재 달의 마지막 날의 주의 토요일로 설정
+  const endDay = new Date(lastDayOfMonth);
+  endDay.setDate(lastDayOfMonth.getDate() + (6 - lastDayOfMonth.getDay()));
+
+  /** startDay부터 endDay까지의 날짜를 주 단위로 그룹화하는 함수 */
+  const groupDatesByWeek = (startDay: Date, endDay: Date) => {
+    const weeks = []; // 최종적으로 주 단위로 그룹화된 날짜 배열들을 저장할 배열
+    let currentWeek = []; // 현재 처리 중인 주를 나타내는 배열
+    const currentDate = new Date(startDay); // 반복 처리를 위한 현재 날짜 변수, 시작 날짜로 초기화
+
+    // 시작 날짜부터 끝 날짜까지 반복
+    while (currentDate <= endDay) {
+      currentWeek.push(new Date(currentDate)); // 현재 날짜를 현재 주에 추가
+      // 현재 주가 7일을 모두 채웠거나 현재 날짜가 토요일인 경우
+      if (currentWeek.length === 7 || currentDate.getDay() === 6) {
+        weeks.push(currentWeek); // 완성된 주를 weeks 배열에 추가
+        currentWeek = []; // 새로운 주를 시작하기 위해 currentWeek을 재초기화
+      }
+      currentDate.setDate(currentDate.getDate() + 1); // 현재 날짜를 다음 날로 변경
+    }
+
+    // 마지막 주 처리 (만약 남아있다면)
+    if (currentWeek.length > 0) {
+      weeks.push(currentWeek); // 남아 있는 날짜가 있다면 마지막 주로 weeks에 추가
+    }
+
+    return weeks; // 주 단위로 그룹화된 날짜 배열들을 반환
+  };
+
+  const weeks = groupDatesByWeek(startDay, endDay);
+
+  // 날짜 비교 함수들
+  const isSameDate = (date1: Date, date2: Date) => {
+    return (
+      date1.getFullYear() === date2.getFullYear() &&
+      date1.getMonth() === date2.getMonth() &&
+      date1.getDate() === date2.getDate()
+    );
+  };
+
+  const isCurrentMonth = (date: Date) => {
+    return date.getMonth() === month;
+  };
+
+  const isPastDate = (date: Date) => {
+    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    return date < todayStart;
+  };
+
+  const handlePrevMonth = () => {
+    if (isCurrentMonthView) return;
+    setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1));
+  };
+
+  const handleNextMonth = () => {
+    if (isMaxMonth) return;
+    setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1));
+  };
+
+  return (
+    <>
+      <div className="flex flex-col gap-5">
+        {/* 제목 닫기버튼 */}
+        <header className="flex justify-between">
+          <h2 className="font-semibold text-lg text-[#161616]">날짜 선택</h2>
+          <button type="button" onClick={setClose}>
+            <Image src={iconClose} alt="닫기" width={24} height={24} />
+          </button>
+        </header>
+        <section>
+          {/* 월 */}
+          <div className="mb-2 h-[26px] flex justify-between">
+            <button
+              type="button"
+              disabled={isCurrentMonthView}
+              className={`${isCurrentMonthView ? "opacity-30 cursor-not-allowed" : "cursor-pointer"}`}
+              onClick={handlePrevMonth}
+            >
+              <Image src={leftIcon} alt="이전 달" width={24} height={24} />
+            </button>
+            <span className="font-semibold text-lg text-[#161616]">
+              {year}.{String(month + 1).padStart(2, "0")}
+            </span>
+            <button
+              type="button"
+              disabled={isMaxMonth}
+              className={`${isMaxMonth ? "opacity-30 cursor-not-allowed" : "cursor-pointer"}`}
+              onClick={handleNextMonth}
+            >
+              <Image src={rightButton} alt="다음 달" width={24} height={24} />
+            </button>
+          </div>
+          {/* 일 */}
+          <div>
+            <div className="grid grid-cols-7 justify-items-center gap-x-2 font-normal text-[13px] text-[#767676]">
+              {["일", "월", "화", "수", "목", "금", "토"].map((d, i) => (
+                <div key={i} className="w-9 h-9 flex justify-center items-center">
+                  {d}
+                </div>
+              ))}
+            </div>
+
+            {/* 날짜 테이블 */}
+            <div className="flex flex-col gap-1">
+              {weeks.map((week, weekIndex) => (
+                <div key={weekIndex} className="grid grid-cols-7 justify-items-center gap-x-2">
+                  {week.map((date, dateIndex) => {
+                    const isSelected = selectedDate && isSameDate(date, selectedDate);
+                    const isToday = isSameDate(date, today);
+                    const isOtherMonth = !isCurrentMonth(date);
+                    const isPast = isPastDate(date);
+                    const isSunday = date.getDay() === 0;
+
+                    return (
+                      <button
+                        key={dateIndex}
+                        type="button"
+                        disabled={isPast || isOtherMonth}
+                        onClick={() => setSelectedDate(date)}
+                        className={`w-9 h-9 flex justify-center items-center rounded-full text-sm
+                          ${isSelected ? " font-semibold text-[white] bg-[#161616]" : ""}
+                          ${isToday && !isSelected ? "border border-[#F1F1F4]" : ""}
+                          ${isOtherMonth ? "text-[#CECECE]" : ""}
+                          ${isPast && !isOtherMonth ? "text-[#CECECE] cursor-not-allowed" : ""}
+                          ${!isSelected && !isOtherMonth && !isPast && !isSunday ? "text-[#161616]" : ""}
+                        `}
+                      >
+                        {date.getDate()}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+        {/* 확인버튼 */}
+        <div>
+          <Button
+            type="button"
+            text="확인"
+            btnSize="medium"
+            bgColor={selectedDate ? "bg-[#06E393]" : "bg-[#E5E5E5]"}
+            textColor={selectedDate ? "text-[#161616]" : "text-[#999999]"}
+            disabled={!selectedDate}
+            onClick={() => {
+              if (selectedDate) {
+                saveSelectedDate(selectedDate);
+                setClose();
+              }
+            }}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/boardgame-frontend/src/components/common/BottomSheet.tsx
+++ b/boardgame-frontend/src/components/common/BottomSheet.tsx
@@ -3,19 +3,19 @@
 import useBottomSheetStore from "@/stores/useBottomSheetStore";
 
 export default function BottomSheet() {
-  const { isOpen, children } = useBottomSheetStore();
+  const { isOpen, children, variant } = useBottomSheetStore();
 
   return (
     <>
       <div
-        className={`absolute inset-0 bg-[#00000066] transition-opacity duration-400 ${
+        className={`absolute inset-0 bg-[#00000066] transition-opacity duration-400 z-50 ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         }`}
       />
       <div
-        className={`w-full p-5 absolute bottom-0 h-5/6 bg-white rounded-t-2xl overflow-hidden transition-transform duration-400 ${
-          isOpen ? "translate-y-0" : "translate-y-full"
-        }`}
+        className={`w-full p-5 absolute bottom-0 left-0 bg-white rounded-t-2xl overflow-hidden transition-transform duration-400 z-50 ${
+          variant === "fixed" ? "h-5/6" : ""
+        } ${isOpen ? "translate-y-0" : "translate-y-full"}`}
       >
         {children}
       </div>

--- a/boardgame-frontend/src/stores/useBottomSheetStore.ts
+++ b/boardgame-frontend/src/stores/useBottomSheetStore.ts
@@ -2,20 +2,29 @@ import { create } from "zustand";
 import { combine } from "zustand/middleware";
 import { ReactNode } from "react";
 
+type BottomSheetVariant = "fixed" | "auto";
+
 type BottomSheetStat = {
   isOpen: boolean;
   children: ReactNode;
+  variant: BottomSheetVariant;
 };
 
 const initialState: BottomSheetStat = {
   isOpen: false,
   children: null,
+  variant: "fixed",
 };
 
 const useBottomSheetStore = create(
   combine(initialState, (set, get) => ({
-    setOpen: (children: ReactNode) => set({ isOpen: true, children }),
-    setClose: () => set(initialState),
+    setOpen: (children: ReactNode, variant: BottomSheetVariant = "fixed") => set({ isOpen: true, children, variant }),
+    setClose: () => {
+      // variant는 유지하고 isOpen만 false로 변경
+      set({ isOpen: false });
+      // 애니메이션 완료 후 children과 variant 초기화 (duration-400 = 400ms)
+      setTimeout(() => set({ children: null, variant: "fixed" }), 400);
+    },
   }))
 );
 

--- a/boardgame-frontend/src/stores/useDateStore.ts
+++ b/boardgame-frontend/src/stores/useDateStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+type DateState = {
+  selectedDate: Date | null;
+};
+
+const initialState: DateState = {
+  selectedDate: null,
+};
+
+const useDateStore = create(
+  combine(initialState, (set) => ({
+    setSelectedDate: (date: Date | null) => set({ selectedDate: date }),
+    clearSelectedDate: () => set({ selectedDate: null }),
+  }))
+);
+
+export default useDateStore;


### PR DESCRIPTION
### 🔖 제목

70 feature 날짜 선택 바텀 시트 구현

<img width="510" height="976" alt="스크린샷 2025-12-03 11 58 24" src="https://github.com/user-attachments/assets/b81a3458-0752-463d-8aa4-87864cae591e" />

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #70 `
    -   `Related to #70 `

---

### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.
-   [✅] 관련 이슈를 연결했습니다.
