### PR TITLE
fix: 엑세스 토큰 갱신 안되는 버그 수정

### DIFF
--- a/boardgame-frontend/src/auth.ts
+++ b/boardgame-frontend/src/auth.ts
@@ -129,7 +129,34 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
 });
 
+// 동시 요청 방지를 위한 Promise 캐시
+let refreshPromise: Promise<JWT> | null = null;
+let currentRefreshToken: string | null = null;
+
 async function refreshAccessToken(token: JWT) {
+  // 이미 같은 refreshToken으로 갱신 중이면 해당 Promise 재사용
+  if (refreshPromise && currentRefreshToken === token.refreshToken) {
+    return refreshPromise;
+  }
+
+  currentRefreshToken = token.refreshToken ?? null;
+
+  refreshPromise = (async () => {
+    try {
+      return await performRefresh(token);
+    } finally {
+      // 현재 갱신이 완료되면 캐시 초기화
+      if (currentRefreshToken === token.refreshToken) {
+        refreshPromise = null;
+        currentRefreshToken = null;
+      }
+    }
+  })();
+
+  return refreshPromise;
+}
+
+async function performRefresh(token: JWT) {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/auth/refresh`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
### 🔖 제목

- fix: 엑세스 토큰 갱신 안되는 버그 수정

---

### 📄 본문

문제 상황:
Next.js + Next-auth 환경에서 여러 컴포넌트가 동시에 auth()를 호출하면, 각각 독립적으로 토큰 갱신 로직을
실행하게 됩니다. 이때 모든 요청이 같은 refresh token을 읽어서 동시에 여러 개의 갱신 요청을 백엔드로 보내게
됩니다.

왜 문제인가:
Refresh token은 보안상 1회용으로 설계되어 있습니다. 한 번 사용되면 즉시 무효화되므로, 동시에 같은 refresh
token으로 여러 요청을 보내면 첫 번째만 성공하고 나머지는 "유효하지 않은 토큰" 에러로 실패합니다.

해결 방법:
동시 요청 방지 코드를 추가하여, 같은 refresh token으로 갱신이 진행 중일 때는 새 요청을 보내지 않고 진행 중인
요청의 결과(Promise)를 재사용합니다. 이렇게 하면 실제로는 1번만 요청이 가고, 모든 컴포넌트가 그 결과를
공유하게 됩니다.

```
if (refreshPromise && currentRefreshToken === token.refreshToken) {
    return refreshPromise; //Promise를 반환하여 기다리게됨
  }

예)
 // 여러 번 await 해도 한 번만 실행됨
  await promise;  // fetch 결과 기다림
  await promise;  // 같은 결과 재사용 (fetch 다시 안 함!)
  await promise;  // 같은 결과 재사용
```

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #105`
    -   `Related to #105`

---

### ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다.
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [ ] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
