### PR TITLE
bug: 모달로 인해 스크롤 안되는 버그 수정

### DIFF
--- a/boardgame-frontend/src/app/layout.tsx
+++ b/boardgame-frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
       <body className="flex justify-center">
         <Providers>
           <div className="w-[375px] min-h-dvh relative overflow-hidden">
-            <div className="w-full">
+            <div className="h-screen overflow-y-scroll scrollbar-hide">
               {children}
               <BottomSheet />
               <Modal />

--- a/boardgame-frontend/src/components/common/Modal.tsx
+++ b/boardgame-frontend/src/components/common/Modal.tsx
@@ -7,12 +7,12 @@ export default function Modal() {
   const { isOpen, content, leftBtnTxt, rightBtnTxt, leftOnClick, rightOnClick } = useModalStore();
 
   useEffect(() => {
-    document.body.style.overflow = "hidden";
+    if (isOpen) document.body.style.overflow = "hidden";
 
     return () => {
       document.body.style.overflow = "unset";
     };
-  }, []);
+  }, [isOpen]);
 
   return (
     <>

--- a/boardgame-frontend/src/components/common/Modal.tsx
+++ b/boardgame-frontend/src/components/common/Modal.tsx
@@ -12,7 +12,7 @@ export default function Modal() {
     return () => {
       document.body.style.overflow = "unset";
     };
-  }, [isOpen]);
+  }, []);
 
   return (
     <>

--- a/boardgame-frontend/src/components/common/Modal.tsx
+++ b/boardgame-frontend/src/components/common/Modal.tsx
@@ -7,7 +7,7 @@ export default function Modal() {
   const { isOpen, content, leftBtnTxt, rightBtnTxt, leftOnClick, rightOnClick } = useModalStore();
 
   useEffect(() => {
-    if (isOpen) document.body.style.overflow = "hidden";
+    document.body.style.overflow = "hidden";
 
     return () => {
       document.body.style.overflow = "unset";


### PR DESCRIPTION
### 🔖 제목

- bug: 모달로 인해 스크롤 안되는 버그 수정

---

### 📄 본문

- 모달이 전역에 있다보니 닫혀있는 경우에도 overflow를 hidden이 되어 isOpen이 true일때만 처리하도록 조건문 추가

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #121`
    -   `Related to #121`

---

### ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다.
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [ ] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
