### PR TITLE
128 feature 마이페이지 상단 모임관리

### DIFF
--- a/boardgame-frontend/next.config.ts
+++ b/boardgame-frontend/next.config.ts
@@ -1,8 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    domains: ["lh3.googleusercontent.com", "k.kakaocdn.net"],
+  },
 };
 
 export default nextConfig;

--- a/boardgame-frontend/src/app/mypage/page.tsx
+++ b/boardgame-frontend/src/app/mypage/page.tsx
@@ -1,10 +1,46 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import NavigationBar from "@/components/common/NavigationBar";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Menu from "@/components/mypage/Menu";
+import { useSession } from "next-auth/react";
 
 export default function Page() {
+  const { data: session } = useSession();
+  const token = session?.user.accessToken as string | undefined;
+  const [myPartData, setMyPartData] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/my/participations/summary`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!res.ok) throw new Error("통신 요청 실패");
+        const data = await res.json();
+        if (mounted) setMyPartData(data);
+      } catch (error: any) {
+        console.error("네트워크 에러", error);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  const participationsData = { ...myPartData };
+
+  const hostLength = participationsData.hostCount;
+  const approvedLength = participationsData.approvedCount;
+  const pendingLength = participationsData.pendingCount;
+
   return (
     <>
       <NavigationBar
@@ -24,14 +60,14 @@ export default function Page() {
           <Link className="flex justify-between items-center cursor-pointer" href="/mypage/profile">
             <div className="flex items-center gap-3 text-lg leading-[26px] font-bold">
               <Image
-                className={"w-12 h-12"}
-                src="/temp_profile.svg"
+                className={"w-12 h-12 rounded-full"}
+                src={session?.user.image || "/temp_profile.svg"}
                 alt="프로필 이미지"
                 width={48}
                 height={48}
                 loading="eager"
               />
-              <span>즐겜러</span>
+              <span>{session?.user.name}</span>
             </div>
             <button>
               <Image className="w-5 h-5" src="/icons/ic_right20.svg" alt="" width={20} height={20} />
@@ -39,21 +75,30 @@ export default function Page() {
           </Link>
           <ul className="mt-4 flex w-full bg-[#F5F6FA] rounded-xl">
             <li className="flex-1 py-3">
-              <Link className="flex flex-col items-center" href="/mypage/meeting/created">
+              <Link
+                className="flex flex-col items-center"
+                href={`/mypage/participated?endPoint=host&length=${hostLength}`}
+              >
                 <span className="text-[#767676] text-xs leading-[18px]">만든모임</span>
-                <span className="text-[#121212] text-xl leading-7 font-medium">2</span>
+                <span className="text-[#121212] text-xl leading-7 font-medium">{hostLength || "0"}</span>
               </Link>
             </li>
             <li className="flex-1 py-3">
-              <Link className="flex flex-col items-center" href="/mypage/meeting/joined">
+              <Link
+                className="flex flex-col items-center"
+                href={`/mypage/participated?endPoint=approved&length=${approvedLength}`}
+              >
                 <span className="text-[#767676] text-xs leading-[18px]">참여한모임</span>
-                <span className="text-[#121212] text-xl leading-7 font-medium">23</span>
+                <span className="text-[#121212] text-xl leading-7 font-medium">{approvedLength || "0"}</span>
               </Link>
             </li>
             <li className="flex-1 py-3">
-              <Link className="flex flex-col items-center" href="/mypage/meeting/waiting">
+              <Link
+                className="flex flex-col items-center"
+                href={`/mypage/participated?endPoint=pending&length=${pendingLength}`}
+              >
                 <span className="text-[#767676] text-xs leading-[18px]">신청 대기중</span>
-                <span className="text-[#121212] text-xl leading-7 font-medium">2</span>
+                <span className="text-[#121212] text-xl leading-7 font-medium">{pendingLength || "0"}</span>
               </Link>
             </li>
           </ul>

--- a/boardgame-frontend/src/app/mypage/participated/page.tsx
+++ b/boardgame-frontend/src/app/mypage/participated/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import backIco from "../../../../public/icons/ic_back.svg";
+import { EmptyState } from "@/components/search";
+
+import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import CardList from "@/components/common/CardList";
+import { useSession } from "next-auth/react";
+import { useState, useEffect, useMemo } from "react";
+
+export default function Page() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session } = useSession();
+  const token = session?.user.accessToken as string | undefined;
+  //배열없음으로하면 결과없음 화면 나오므로 null로 기본값 설정
+  const [results, setResults] = useState<any[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 쿼리에서 읽기
+  const raw = searchParams?.get("endPoint") ?? "approved";
+  const endPoint = raw === "pending" ? "pending" : raw === "host" ? "host" : "approved";
+  const cardLength = Number(searchParams?.get("length"));
+
+  //무한 스크롤...
+  const [page, setPage] = useState<number>(0);
+  const [size, setSize] = useState<number>(10);
+
+  const meetingEndpointUrl = {
+    PENDING: `/api/my/participations/pending`,
+    APPROVED: "/api/my/participations/approved",
+    HOST: (page = 0, size = 5) => `/api/my/participations/host/meetings?page=${page}&size=${size}`,
+  };
+
+  let url = "";
+  if (endPoint === "pending") url = meetingEndpointUrl.PENDING;
+  else if (endPoint === "approved") url = meetingEndpointUrl.APPROVED;
+  else if (endPoint === "host") url = meetingEndpointUrl.HOST(page, size);
+
+  let title = "";
+  if (endPoint === "pending") title = "신청 대기중";
+  else if (endPoint === "approved") title = "참여한 모임";
+  else if (endPoint === "host") title = "만든 모임";
+
+  useEffect(() => {
+    if (!token) return;
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}${url}`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!res.ok) throw new Error("통신 요청 실패");
+        const data = await res.json();
+        // 응답을 항상 배열로 정규화
+        const normalize = (d: any) => {
+          if (Array.isArray(d)) return d;
+          if (!d) return [];
+          if (Array.isArray(d.content)) return d.content;
+          return [];
+        };
+        if (mounted) setResults(normalize(data));
+      } catch (error: any) {
+        console.error("네트워크 에러", error);
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [token, url, page, size]);
+
+  console.log("페치결과", results);
+
+  //참여모임은 다가오는 모임을 분류
+  const [upcoming, finished] = useMemo(() => {
+    const now = Date.now();
+    const u: any[] = [];
+    const f: any[] = [];
+    (results || []).forEach((item: any) => {
+      const t = item?.meetingAt ? new Date(item.meetingAt).getTime() : NaN;
+      if (Number.isNaN(t)) {
+        // meetingAt 없거나 파싱 실패 시는 upcoming에 두거나 로직에 맞게 처리
+        u.push(item);
+      } else if (t > now) {
+        u.push(item);
+      } else {
+        f.push(item);
+      }
+    });
+    // 정렬: 다가오는 건 오름차순, 완료는 내림차순
+    u.sort((a, b) => new Date(a.meetingAt).getTime() - new Date(b.meetingAt).getTime());
+    f.sort((a, b) => new Date(b.meetingAt).getTime() - new Date(a.meetingAt).getTime());
+    return [u, f];
+  }, [results]);
+
+  return (
+    <div className="pt-11 px-5 max-w-[375px] h-screen flex flex-col overflow-y-scroll scrollbar-hide">
+      <header className="h-[60px] flex items-center gap-3">
+        <button type="button" onClick={() => router.back()}>
+          <Image src={backIco} alt="뒤로가기" width={24} height={24} />
+        </button>
+        <h1 className="font-bold text-xl text-[#161616]">{title}</h1>
+      </header>
+      <main className="py-2 flex-1">
+        {/* 결과가 없으면 */}
+        {loading ? (
+          <div className="flex flex-col gap-2 items-center">
+            {Array.from({ length: cardLength }).map((_, i) => (
+              <div key={i} className="w-[335px] h-[116px] rounded-2xl p-4 bg-white animate-pulse" />
+            ))}
+          </div>
+        ) : results.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <EmptyState />
+          </div>
+        ) : endPoint === "approved" ? (
+          // 참가 승인 모집
+          <>
+            <div className="flex flex-col pt-2 px-5 gap-2.5">
+              <h2 className=" font-medium text-sm text-[#767676]">다가오는 모임</h2>
+              <CardList results={upcoming} />
+            </div>
+            <div className="flex flex-col pt-2 px-5 gap-2.5">
+              <h2 className=" font-medium text-sm text-[#767676]">참여 완료</h2>
+              <CardList results={finished} />
+            </div>
+          </>
+        ) : (
+          // 승인 대기중 모집
+          <div className="flex flex-col pt-2 px-5 gap-2.5">
+            <CardList results={results} />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/boardgame-frontend/src/components/board/MeetingJoinButton.tsx
+++ b/boardgame-frontend/src/components/board/MeetingJoinButton.tsx
@@ -48,7 +48,7 @@ export default function MeetingJoinButton({ id, participants, maxParticipants }:
       console.error("통신 에러", error);
     } finally {
       setIsLoading(false);
-      router.push(`/board/${id}`);
+      router.back();
     }
   }
 

--- a/boardgame-frontend/src/hooks/useMeetingDetail.tsx
+++ b/boardgame-frontend/src/hooks/useMeetingDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+
 import { Post } from "@/types/post";
 
 export default function useMeetingDetail(id: string) {


### PR DESCRIPTION
### 🔖 제목


128 feature 마이페이지 상단 모임관리



상세

1. 마이페이지 상단 api 연결

<img width="376" height="182" alt="스크린샷 2025-12-12 18 00 45" src="https://github.com/user-attachments/assets/2fec2fc0-340c-479e-90af-9e1086eabd4d" />

2. 각 링크 participated 페이지로 라우팅

3. 접근 파라미터에 따라 다르게 렌더링 처리

<img width="425" height="755" alt="스크린샷 2025-12-12 18 01 34" src="https://github.com/user-attachments/assets/c8b9d22e-7863-4942-a100-126a14e15488" />

4. 로딩중 스켈레톤 제작 (상위컴포넌트에서 리스트 갯수 파라미터로 가져와 로딩)
<img width="413" height="404" alt="스크린샷 2025-12-12 18 02 50" src="https://github.com/user-attachments/assets/1edfa6c5-714a-4e14-9a76-5f622adec11a" />

5. 각 게시물 신청 취소/ 수정 기능 연결

/** 중요 추가 노트
아직 내가 만든 모임을 어떻게 처리하는지(삭제 혹은 인원관리) 기능이 미구현입니다.
아직 신청 취소등 완료 후 모달기능이 미구현입니다.


---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #128 `
    -   `Related to #128`

---

### ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다.
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [ ] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
