### PR TITLE
fix/외부 도메인 허용하는 방법을 remotePatterns로 변경

### DIFF
--- a/boardgame-frontend/next.config.ts
+++ b/boardgame-frontend/next.config.ts
@@ -3,7 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactCompiler: true,
   images: {
-    domains: ["lh3.googleusercontent.com", "k.kakaocdn.net"],
+    remotePatterns: [
+      { protocol: "https", hostname: "**.kakaocdn.net" },
+      { protocol: "http", hostname: "**.kakaocdn.net" },
+      { protocol: "https", hostname: "**.googleusercontent.com" },
+      { protocol: "http", hostname: "**.googleusercontent.com" },
+    ],
   },
 };
 


### PR DESCRIPTION
### 🔖 제목

fix/외부 도메인 허용하는 방법을 remotePatterns로 변경
---

기존 next.config에서 고정으로 도메인을 허용하던 방법에서
리모트 패턴을 사용해 유연하게 변경

기존 : "k.kakaocnd.net"
변경 : "**.kakaocnd.net"



### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #142 `
    -   `Related to #142 `

---
