### PR TITLE
fix/badge컴포넌트가 달라붙던 현상 해결(map함수 누락 수정)

### DIFF
--- a/boardgame-frontend/src/app/board/[id]/page.tsx
+++ b/boardgame-frontend/src/app/board/[id]/page.tsx
@@ -67,7 +67,11 @@ export default function Page() {
           {/* 태그 리스트 */}
           <ul className="flex gap-1 text-[13px] text-[#767676] font-medium leading-5 mt-3">
             <Badge>{`${currentParticipants}/${maxParticipants === 99 ? "무제한" : maxParticipants} 명`}</Badge>
-            {gameList ? <Badge>{gameList}</Badge> : ""}
+            {gameList
+              ? gameList.map((v: string, i: number) => {
+                  return <Badge key={i}>{v}</Badge>;
+                })
+              : ""}
           </ul>
           {/* 게시글 내용 */}
           <p className="whitespace-pre-line mt-4 bg-[#F5F6FA] rounded-xl p-3 text-sm text-[#161616] leading-[22px]">


### PR DESCRIPTION
### 🔖 제목

fix/badge컴포넌트가 달라붙던 현상 해결(map함수 누락 수정)
---

### 📄 본문

기존 버그
게임 리스트가 달라붙어서 렌더되던 현상

<img width="500" height="683" alt="bug1" src="https://github.com/user-attachments/assets/f7f08f40-525f-42cf-9525-b5d5383abd69" />



수정

게임 리스트가 따로 보이도록 수정
<img width="251" height="58" alt="스크린샷 2025-12-16 00 32 16" src="https://github.com/user-attachments/assets/b5133a34-5be0-4dae-a440-9ed6db0a4fe6" />

---



### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
