### PR TITLE
fix/최상단 알림메뉴 제거

### DIFF
--- a/boardgame-frontend/src/app/mypage/page.tsx
+++ b/boardgame-frontend/src/app/mypage/page.tsx
@@ -161,19 +161,7 @@ export default function Page() {
         <section className="mt-3">
           <h2 className="sr-only">마이페이지 메뉴 목록</h2>
           <ul className="flex flex-col gap-[1px]">
-            <Menu
-              title="알림 설정"
-              isTop={true}
-              elements={
-                <button
-                  className="flex items-center justify-end w-[38px] h-5 p-[2px] bg-[#06E393] rounded-[1000000000px]"
-                  aria-label="알림설정 ON/OFF 버튼"
-                >
-                  <span className="inline-block w-4 h-4 rounded-[50%] bg-white"></span>
-                </button>
-              }
-            />
-            <Menu title="서비스 이용 약관" />
+            <Menu title="서비스 이용 약관" isTop={true} />
             <Menu title="개인정보 처리 약관" />
             <Menu title="위치 정보 이용 약관" />
             <Menu title="1:1 문의" isBottom={true} />


### PR DESCRIPTION
### 🔖 제목


fix/최상단 알림메뉴 제거

---

<img width="390" height="306" alt="스크린샷 2025-12-16 01 06 07" src="https://github.com/user-attachments/assets/72b0a525-e87d-40d2-98fe-e2605bc9f452" />

상단 알림 메뉴 제거
(디자인/기능 수정으로 사용되지 않음)

---


### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.
-   [ ] 관련 이슈를 연결했습니다.
