### PR TITLE
158 bug 상세페이지 신청 버튼 style 수정

### DIFF
--- a/boardgame-frontend/src/app/board/[id]/page.tsx
+++ b/boardgame-frontend/src/app/board/[id]/page.tsx
@@ -56,11 +56,11 @@ export default function Page() {
   const gameList = gameListMaker(gameNamesJson);
 
   return (
-    <>
+    <div className="flex flex-col min-h-screen">
       {/* 헤더 */}
       <Header host={amIHost} id={id} />
       {/* 메인 */}
-      <main className="pb-[60px]">
+      <main className="pb-[60px] flex-1">
         <section className="px-5 mt-2.5">
           {/* 제목 */}
           <h1 className="text-[20px] leading-7 font-bold">{title}</h1>
@@ -94,10 +94,11 @@ export default function Page() {
         <div className="h-2.5 bg-[#F5F6FA] mt-5" role="separator" aria-hidden="true"></div>
         {/* 참여 인원 */}
         <MemberList participants={participants} host={host} />
-
+      </main>
+      <footer className="flex justify-center">
         {/* 참가신청 버튼 */}
         {!amIHost && <MeetingJoinButton id={id} participants={participants} maxParticipants={maxParticipants} />}
-      </main>
-    </>
+      </footer>
+    </div>
   );
 }

--- a/boardgame-frontend/src/components/board/MeetingJoinButton.tsx
+++ b/boardgame-frontend/src/components/board/MeetingJoinButton.tsx
@@ -113,7 +113,7 @@ export default function MeetingJoinButton({ id, participants, maxParticipants }:
   }, [participants, maxParticipants, session?.user?.name]);
 
   return (
-    <div className="mb-1.5 fixed bottom-0 right-0 left-1/2 -translate-x-1/2 w-full max-w-[335px]">
+    <div className="mb-1.5 w-full max-w-[335px]">
       <button
         className={`w-full ${buttonColor || !isLoading ? "bg-[#06E393]" : "bg-[#EEF0F7]"} text-sm leading-[22px] text-[#161616] font-semibold py-[11px] rounded-[10px] cursor-pointer`}
         type="button"


### PR DESCRIPTION
### 🔖 제목

158 bug 상세페이지 신청 버튼 style 수정
---

버튼 스타일이 fixed로 bottom에서 항상 6px떨어져 있었지만, 화면 길이가 콘텐츠보다 짧을시
다른 콘텐츠와 겹치는 현상을 수정했습니다.

수정방법
1. 버튼 스타일 fixed 제거
2. 상위 페이지 main을 flex-1을 주어 화면 길이만큼 늘어나게 수정
3. 버튼을 가장 밑에 두어 항상 바닥에 있게 수정



---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #158 `
    -   `Related to #158 `

---

### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.
-   [✅] 관련 이슈를 연결했습니다.
