### PR TITLE
161 refactor region state session storage

### DIFF
--- a/boardgame-frontend/src/app/api/location/address2coord/route.ts
+++ b/boardgame-frontend/src/app/api/location/address2coord/route.ts
@@ -40,19 +40,13 @@ export async function GET(request: NextRequest) {
           region2 = doc.address?.region_2depth_name || "";
         }
 
-        return {
-          region_1depth_name: region1,
-          region_2depth_name: region2,
-        };
+        return `${region1} ${region2}`;
       })
-      .filter((item: any) => item.region_1depth_name && item.region_2depth_name);
+      .filter((item: any) => item);
 
     //주소 중복제거
-    const uniqueResults = Array.from(
-      new Map(
-        filteredResults.map((item: any) => [`${item.region_1depth_name}-${item.region_2depth_name}`, item])
-      ).values()
-    );
+    const uniqueResults = Array.from(new Set(filteredResults));
+    console.log("data:", data, "address:", filteredResults, "uniqueAddress:", uniqueResults);
 
     return NextResponse.json({ documents: uniqueResults });
   } catch (error) {

--- a/boardgame-frontend/src/app/api/location/address2coord/route.ts
+++ b/boardgame-frontend/src/app/api/location/address2coord/route.ts
@@ -46,7 +46,6 @@ export async function GET(request: NextRequest) {
 
     //주소 중복제거
     const uniqueResults = Array.from(new Set(filteredResults));
-    console.log("data:", data, "address:", filteredResults, "uniqueAddress:", uniqueResults);
 
     return NextResponse.json({ documents: uniqueResults });
   } catch (error) {

--- a/boardgame-frontend/src/app/api/location/address2coord/route.ts
+++ b/boardgame-frontend/src/app/api/location/address2coord/route.ts
@@ -40,9 +40,8 @@ export async function GET(request: NextRequest) {
           region2 = doc.address?.region_2depth_name || "";
         }
 
-        return `${region1} ${region2}`;
-      })
-      .filter((item: any) => item);
+        return `${region1} ${region2}`.trim();
+      });
 
     //주소 중복제거
     const uniqueResults = Array.from(new Set(filteredResults));

--- a/boardgame-frontend/src/app/api/location/address2coord/route.ts
+++ b/boardgame-frontend/src/app/api/location/address2coord/route.ts
@@ -40,10 +40,6 @@ export async function GET(request: NextRequest) {
           region2 = doc.address?.region_2depth_name || "";
         }
 
-        region1 = region1.replace(/제주특별자치도/, "제주도");
-        region1 = region1.replace(/특별자치도/, "");
-        region1 = region1.replace(/특별자치시/, "");
-
         return {
           region_1depth_name: region1,
           region_2depth_name: region2,

--- a/boardgame-frontend/src/app/api/location/coord2address/route.ts
+++ b/boardgame-frontend/src/app/api/location/coord2address/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "서버 설정 오류: API 키가 없습니다" }, { status: 500 });
     }
 
-    const url = `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${x}&y=${y}`;
+    const url = `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${x}&y=${y}`;
 
     const response = await fetch(url, {
       headers: {
@@ -46,16 +46,9 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json();
-
-    let addressList = data.documents.filter((doc: any) => doc.region_type === "H");
-
-    addressList = addressList.map((doc: any) => {
-      let regionName = doc.region_1depth_name || doc.address_name || "";
-
-      return {
-        ...doc,
-        region_1depth_name: regionName.trim(),
-      };
+    let addressList = data.documents.map((doc: any) => {
+      const address = doc.address;
+      return `${address.region_1depth_name} ${address.region_2depth_name}`;
     });
 
     return NextResponse.json({ documents: addressList });

--- a/boardgame-frontend/src/app/api/location/coord2region/route.ts
+++ b/boardgame-frontend/src/app/api/location/coord2region/route.ts
@@ -6,9 +6,6 @@ export async function GET(request: NextRequest) {
     const x = searchParams.get("x");
     const y = searchParams.get("y");
 
-    console.log("=== coord2region API 호출 ===");
-    console.log("좌표:", { x, y });
-
     if (!x || !y) {
       console.error("좌표 없음");
       return NextResponse.json({ error: "좌표 정보가 필요합니다" }, { status: 400 });
@@ -54,9 +51,6 @@ export async function GET(request: NextRequest) {
 
     addressList = addressList.map((doc: any) => {
       let regionName = doc.region_1depth_name || doc.address_name || "";
-      regionName = regionName.replace(/제주특별자치도$/, "제주도");
-      regionName = regionName.replace(/특별자치도$/, "");
-      regionName = regionName.replace(/^경기도/, "경기");
 
       return {
         ...doc,

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -30,14 +30,10 @@ export default function Home() {
 
   // 서버에서 region 가져오기
   async function getRegion() {
-    if (!session?.user?.accessToken) {
-      return;
-    }
-
     try {
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/users/me`, {
         headers: {
-          Authorization: `Bearer ${session.user.accessToken}`,
+          Authorization: `Bearer ${session?.user.accessToken}`,
         },
       });
 
@@ -63,8 +59,10 @@ export default function Home() {
 
   // 초기 로딩: 인증 완료 시 서버에서 region 가져오기
   useEffect(() => {
-    if (status === "authenticated") {
+    if (status === "authenticated" && !isRegionLoaded) {
       getRegion();
+    } else if (status === "unauthenticated") {
+      setRegion("서울 강남구");
     }
   }, [status]);
 
@@ -75,7 +73,7 @@ export default function Home() {
       const date = `${year}${month}${day}`;
 
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}&regionCode=${region}`
+        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}`
       );
 
       if (!res.ok) throw new Error("데이터 fetch 에러");

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -44,9 +44,8 @@ export default function Home() {
       const date = `${year}${month}${day}`;
 
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}`
+        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}&regionCode=${selectedRegion}`
       );
-      // 지역 파라미터 추가 예정: &regionCode=${selectedRegion}
 
       if (!res.ok) throw new Error("데이터 fetch 에러");
 

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import Calendar from "@/components/common/Calendar";
 import CardList from "@/components/common/CardList";
 import Header from "@/components/common/Header";
 import { EmptyState } from "@/components/search";
+import useRegionStore from "@/stores/useRegionStore";
 import { Post } from "@/types/post";
 import dateFormatter from "@/util/dateFormatter";
 import { useSession } from "next-auth/react";
@@ -25,46 +26,16 @@ export default function Home() {
 
   const today = new Date();
   const [selectedDate, setSelectedDate] = useState<Date>(today);
-  const [region, setRegion] = useState<string>("");
-  const [isRegionLoaded, setIsRegionLoaded] = useState(false); //활동지역 로딩 상태
 
-  // 서버에서 region 가져오기
-  async function getRegion() {
-    try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/users/me`, {
-        headers: {
-          Authorization: `Bearer ${session?.user.accessToken}`,
-        },
-      });
+  const { selectedRegion, initializeRegion, isInitialized } = useRegionStore();
 
-      if (!res.ok) throw new Error("지역 정보 fetch 에러");
-
-      const data = await res.json();
-
-      if (data.region) {
-        setRegion(data.region);
-      }
-    } catch (error) {
-      setRegion("서울 강남구");
-      console.error("통신 에러", error);
-    } finally {
-      setIsRegionLoaded(true);
-    }
-  }
-
-  // Header에서 지역 변경 시 호출되는 함수
-  const handleRegionChange = async (newRegion: string) => {
-    setRegion(newRegion);
-  };
-
-  // 초기 로딩: 인증 완료 시 서버에서 region 가져오기
   useEffect(() => {
-    if (status === "authenticated" && !isRegionLoaded) {
-      getRegion();
+    if (status === "authenticated" && session?.user?.accessToken) {
+      initializeRegion(session.user.accessToken);
     } else if (status === "unauthenticated") {
-      setRegion("서울 강남구");
+      // 비로그인 상태면 기본값 사용 (이미 "서울 강남구"로 초기화됨)
     }
-  }, [status]);
+  }, [status, session?.user?.accessToken]);
 
   async function getData(pageNum: number) {
     try {
@@ -75,6 +46,7 @@ export default function Home() {
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}`
       );
+      // 지역 파라미터 추가 예정: &regionCode=${selectedRegion}
 
       if (!res.ok) throw new Error("데이터 fetch 에러");
 
@@ -98,11 +70,13 @@ export default function Home() {
   }
 
   useEffect(() => {
-    setPostings([]);
-    setPage(0);
-    setHasMore(true);
-    getData(0);
-  }, [selectedDate, region]);
+    if (isInitialized) {
+      setPostings([]);
+      setPage(0);
+      setHasMore(true);
+      getData(0);
+    }
+  }, [selectedDate, selectedRegion]);
 
   useEffect(() => {
     if (inView && !isLoading && hasMore && page > 0) {
@@ -113,7 +87,7 @@ export default function Home() {
   return (
     <div className="flex justify-center">
       <div className="w-full min-h-screen flex flex-col items-center bg-[#F5F6FA] relative">
-        <Header region={region} changeRegion={handleRegionChange} />
+        <Header />
         <main className="flex-1 flex flex-col w-full">
           <section className="w-full flex flex-col items-center">
             <Banner />

--- a/boardgame-frontend/src/components/board/CreateBoard.tsx
+++ b/boardgame-frontend/src/components/board/CreateBoard.tsx
@@ -14,14 +14,14 @@ import useGameStore from "@/stores/post/useGameStore";
 import useBottomSheetStore from "@/stores/useBottomSheetStore";
 import dateFormatter, { formatDateTime } from "@/util/dateFormatter";
 
+import useMeetingDetail from "@/hooks/useMeetingDetail";
+import usePlaceStore from "@/stores/post/usePlaceStore";
+import useToastMessage from "@/stores/useToastMessage";
+import { useSession } from "next-auth/react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import usePlaceStore from "@/stores/post/usePlaceStore";
-import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
-import useMeetingDetail from "@/hooks/useMeetingDetail";
-import useToastMessage from "@/stores/useToastMessage";
 
 interface MeetingFormData {
   meetingId: number;
@@ -99,7 +99,7 @@ export default function CreateBoard({ id }: { id: number }) {
     data.gameNames = [...games];
     data.meetingPlace = meetingPlace;
     data.meetingAddress = meetingAddress;
-    data.regionCode = meetingAddress.split(" ")[0] + " " + meetingAddress.split(" ")[1];
+    data.regionCode = meetingAddress;
     data.meetingAt = `${year}-${month}-${day}T${hours}:${minutes}:00`;
     data.maxParticipants = people;
 

--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -14,7 +14,7 @@ export default function RegionSelect() {
   const [regionInput, setRegionInput] = useState("");
   const debouncedSearch = useDebounce(regionInput, 300);
   const { searchResults, isLoading, getCurrentRegion, searchAddress } = useRegion();
-  const { region, setRegion } = useRegionStore();
+  const { setSelectedRegion } = useRegionStore();
 
   useEffect(() => {
     if (debouncedSearch) {
@@ -30,8 +30,17 @@ export default function RegionSelect() {
     setRegionInput(e.target.value);
   };
 
+  const formatAddress = (address: string) => {
+    return address
+      .replace(/제주특별자치도/g, "제주도")
+      .replace(/특별자치도/g, "")
+      .replace(/특별자치시/g, "")
+      .replace(/경기도/g, "경기")
+      .trim();
+  };
+
   const handleRegionSelect = (locationString: string) => {
-    setRegion(locationString); // 전역 상태에 선택한 지역 저장
+    setSelectedRegion(formatAddress(locationString)); // 전역 상태에 선택한 지역 저장
     setClose(); // 바텀시트 닫기
   };
 
@@ -81,7 +90,7 @@ export default function RegionSelect() {
                     onClick={() => handleRegionSelect(locationString)}
                     className="w-full text-left transition-colors cursor-pointer"
                   >
-                    {locationString}
+                    {formatAddress(locationString)}
                   </button>
                 </li>
               );

--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -30,14 +30,14 @@ export default function RegionSelect() {
     setRegionInput(e.target.value);
   };
 
-  const formatAddress = (address: string) => {
-    return address
-      .replace(/제주특별자치도/g, "제주도")
-      .replace(/특별자치도/g, "")
-      .replace(/특별자치시/g, "")
-      .replace(/경기도/g, "경기")
-      .trim();
-  };
+  // const formatAddress = (address: string) => {
+  //   return address
+  //     .replace(/제주특별자치도/g, "제주도")
+  //     .replace(/특별자치도/g, "")
+  //     .replace(/특별자치시/g, "")
+  //     .replace(/경기도/g, "경기")
+  //     .trim();
+  // };
 
   const handleRegionSelect = (locationString: string) => {
     setSelectedRegion(locationString.replace(/경기도/g, "경기")); // 전역 상태에 선택한 지역 저장
@@ -81,7 +81,7 @@ export default function RegionSelect() {
           <h3 className="text-xs">검색 결과</h3>
           <ul>
             {searchResults.map((result, index) => {
-              const locationString = [result.region_1depth_name, result.region_2depth_name].filter(Boolean).join(" ");
+              const locationString = `${result}`;
 
               return (
                 <li key={index} className="my-3 text-[#161616]">
@@ -90,7 +90,7 @@ export default function RegionSelect() {
                     onClick={() => handleRegionSelect(locationString)}
                     className="w-full text-left transition-colors cursor-pointer"
                   >
-                    {formatAddress(locationString)}
+                    {locationString}
                   </button>
                 </li>
               );

--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -4,21 +4,17 @@ import Button from "@/components/common/Button";
 import TextInput from "@/components/common/TextInput";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useRegion } from "@/hooks/useRegion";
-import { useSession } from "next-auth/react";
+import useBottomSheetStore from "@/stores/useBottomSheetStore";
+import useRegionStore from "@/stores/useRegionStore";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import useBottomSheetStore from "../../stores/useBottomSheetStore";
 
-interface RegionSelectProps {
-  onSelect: (region: string) => void;
-}
-
-export default function RegionSelect({ onSelect }: RegionSelectProps) {
-  const { data: session, status } = useSession();
+export default function RegionSelect() {
   const { setClose } = useBottomSheetStore();
   const [regionInput, setRegionInput] = useState("");
   const debouncedSearch = useDebounce(regionInput, 300);
   const { searchResults, isLoading, getCurrentRegion, searchAddress } = useRegion();
+  const { region, setRegion } = useRegionStore();
 
   useEffect(() => {
     if (debouncedSearch) {
@@ -27,7 +23,7 @@ export default function RegionSelect({ onSelect }: RegionSelectProps) {
   }, [debouncedSearch]);
 
   const handleCurrentRegionClick = async () => {
-    const results = await getCurrentRegion();
+    return await getCurrentRegion();
   };
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +31,7 @@ export default function RegionSelect({ onSelect }: RegionSelectProps) {
   };
 
   const handleRegionSelect = (locationString: string) => {
-    onSelect(locationString); // 부모에게 선택된 지역 전달
+    setRegion(locationString); // 전역 상태에 선택한 지역 저장
     setClose(); // 바텀시트 닫기
   };
 

--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -40,7 +40,7 @@ export default function RegionSelect() {
   };
 
   const handleRegionSelect = (locationString: string) => {
-    setSelectedRegion(formatAddress(locationString)); // 전역 상태에 선택한 지역 저장
+    setSelectedRegion(locationString.replace(/경기도/g, "경기")); // 전역 상태에 선택한 지역 저장
     setClose(); // 바텀시트 닫기
   };
 

--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -30,15 +30,6 @@ export default function RegionSelect() {
     setRegionInput(e.target.value);
   };
 
-  // const formatAddress = (address: string) => {
-  //   return address
-  //     .replace(/제주특별자치도/g, "제주도")
-  //     .replace(/특별자치도/g, "")
-  //     .replace(/특별자치시/g, "")
-  //     .replace(/경기도/g, "경기")
-  //     .trim();
-  // };
-
   const handleRegionSelect = (locationString: string) => {
     setSelectedRegion(locationString.replace(/경기도/g, "경기")); // 전역 상태에 선택한 지역 저장
     setClose(); // 바텀시트 닫기

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -18,14 +18,14 @@ export default function Header() {
     setOpen(<RegionSelect />, "auto");
   };
 
-  const formatAddress = (address: string) => {
-    return address
-      .replace(/제주특별자치도/g, "제주도")
-      .replace(/특별자치도/g, "")
-      .replace(/특별자치시/g, "")
-      .replace(/경기도/g, "경기")
-      .trim();
-  };
+  // const formatAddress = (address: string) => {
+  //   return address
+  //     .replace(/제주특별자치도/g, "제주도")
+  //     .replace(/특별자치도/g, "")
+  //     .replace(/특별자치시/g, "")
+  //     .replace(/경기도/g, "경기")
+  //     .trim();
+  // };
 
   return (
     <header className="w-full px-5 py-3 mt-11 mb-3 text-xl font-bold flex justify-between">
@@ -33,7 +33,7 @@ export default function Header() {
 
       <div className="relative inline-block">
         <button onClick={handleRegionSelect} className="flex items-center gap-[2px] cursor-pointer outline-none">
-          <span>{formatAddress(selectedRegion)}</span>
+          <span>{selectedRegion}</span>
           <Image src="/icons/ic_dropdown.svg" width={24} height={24} alt="dropdown" />
         </button>
       </div>

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -6,10 +6,6 @@ import useRegionStore from "@/stores/useRegionStore";
 import Image from "next/image";
 import Link from "next/link";
 
-interface HeaderProps {
-  region: string;
-}
-
 export default function Header() {
   const { setOpen } = useBottomSheetStore();
   const { selectedRegion } = useRegionStore();
@@ -17,15 +13,6 @@ export default function Header() {
   const handleRegionSelect = () => {
     setOpen(<RegionSelect />, "auto");
   };
-
-  // const formatAddress = (address: string) => {
-  //   return address
-  //     .replace(/제주특별자치도/g, "제주도")
-  //     .replace(/특별자치도/g, "")
-  //     .replace(/특별자치시/g, "")
-  //     .replace(/경기도/g, "경기")
-  //     .trim();
-  // };
 
   return (
     <header className="w-full px-5 py-3 mt-11 mb-3 text-xl font-bold flex justify-between">

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -4,17 +4,18 @@ import RegionSelect from "@/components/bottom-sheet/RegionSelect";
 import useBottomSheetStore from "@/stores/useBottomSheetStore";
 import Image from "next/image";
 import Link from "next/link";
+import useRegionStore from "../../stores/useRegionStore";
 
 interface HeaderProps {
   region: string;
-  changeRegion: (region: string) => void;
 }
 
-export default function Header({ region, changeRegion }: HeaderProps) {
+export default function Header() {
   const { setOpen } = useBottomSheetStore();
+  const { region } = useRegionStore();
 
   const handleRegionSelect = () => {
-    setOpen(<RegionSelect onSelect={(region) => changeRegion(region)} />, "auto");
+    setOpen(<RegionSelect />, "auto");
   };
 
   return (

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -2,9 +2,9 @@
 
 import RegionSelect from "@/components/bottom-sheet/RegionSelect";
 import useBottomSheetStore from "@/stores/useBottomSheetStore";
+import useRegionStore from "@/stores/useRegionStore";
 import Image from "next/image";
 import Link from "next/link";
-import useRegionStore from "../../stores/useRegionStore";
 
 interface HeaderProps {
   region: string;
@@ -12,10 +12,19 @@ interface HeaderProps {
 
 export default function Header() {
   const { setOpen } = useBottomSheetStore();
-  const { region } = useRegionStore();
+  const { selectedRegion } = useRegionStore();
 
   const handleRegionSelect = () => {
     setOpen(<RegionSelect />, "auto");
+  };
+
+  const formatAddress = (address: string) => {
+    return address
+      .replace(/제주특별자치도/g, "제주도")
+      .replace(/특별자치도/g, "")
+      .replace(/특별자치시/g, "")
+      .replace(/경기도/g, "경기")
+      .trim();
   };
 
   return (
@@ -24,7 +33,7 @@ export default function Header() {
 
       <div className="relative inline-block">
         <button onClick={handleRegionSelect} className="flex items-center gap-[2px] cursor-pointer outline-none">
-          <span>{region}</span>
+          <span>{formatAddress(selectedRegion)}</span>
           <Image src="/icons/ic_dropdown.svg" width={24} height={24} alt="dropdown" />
         </button>
       </div>

--- a/boardgame-frontend/src/components/common/Header.tsx
+++ b/boardgame-frontend/src/components/common/Header.tsx
@@ -19,7 +19,11 @@ export default function Header() {
       <h1 className="sr-only">보드게임 친구 찾을때 보드메이트!</h1>
 
       <div className="relative inline-block">
-        <button onClick={handleRegionSelect} className="flex items-center gap-[2px] cursor-pointer outline-none">
+        <button
+          onClick={handleRegionSelect}
+          className="flex items-center gap-[2px] cursor-pointer outline-none"
+          type="button"
+        >
           <span>{selectedRegion}</span>
           <Image src="/icons/ic_dropdown.svg" width={24} height={24} alt="dropdown" />
         </button>

--- a/boardgame-frontend/src/hooks/useRegion.ts
+++ b/boardgame-frontend/src/hooks/useRegion.ts
@@ -102,28 +102,6 @@ export function useRegion() {
     }
   };
 
-  // 현재 위치 좌표 가져오기 (키워드 검색용)
-  const getCurrentPosition = (): Promise<{ x: number; y: number }> => {
-    return new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
-        reject(new Error("위치 서비스를 지원하지 않는 브라우저입니다."));
-        return;
-      }
-
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          resolve({
-            x: position.coords.longitude,
-            y: position.coords.latitude,
-          });
-        },
-        (error) => {
-          reject(new Error("위치 정보를 가져올 수 없습니다."));
-        }
-      );
-    });
-  };
-
   // 키워드로 장소 검색
   const searchPlaces = async (keyword: string) => {
     if (!keyword.trim()) {

--- a/boardgame-frontend/src/hooks/useRegion.ts
+++ b/boardgame-frontend/src/hooks/useRegion.ts
@@ -49,7 +49,7 @@ export function useRegion() {
 
       const { latitude, longitude } = position.coords;
 
-      const response = await fetch(`/api/location/coord2region?x=${longitude}&y=${latitude}`);
+      const response = await fetch(`/api/location/coord2address?x=${longitude}&y=${latitude}`);
 
       if (!response.ok) {
         throw new Error("위치 정보를 가져올 수 없습니다");

--- a/boardgame-frontend/src/stores/useRegionStore.ts
+++ b/boardgame-frontend/src/stores/useRegionStore.ts
@@ -44,7 +44,6 @@ const useRegionStore = create<SearchStore>()(
           console.error("지역 정보 로드 실패:", error);
           set({
             selectedRegion: "서울 강남구",
-            isInitialized: true,
           });
         }
       },

--- a/boardgame-frontend/src/stores/useRegionStore.ts
+++ b/boardgame-frontend/src/stores/useRegionStore.ts
@@ -1,0 +1,70 @@
+// stores/useRegionStore.ts
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface SearchStore {
+  selectedRegion: string;
+  isInitialized: boolean;
+
+  setSelectedRegion: (region: string) => void;
+  initializeRegion: (accessToken: string) => Promise<void>;
+}
+
+const useRegionStore = create<SearchStore>()(
+  persist(
+    (set, get) => ({
+      selectedRegion: "서울 강남구",
+      isInitialized: false,
+
+      setSelectedRegion: (region: string) => {
+        set({ selectedRegion: region });
+      },
+
+      initializeRegion: async (accessToken: string) => {
+        // 이미 초기화됐으면 API 호출 안 함
+        if (get().isInitialized) {
+          return;
+        }
+
+        try {
+          const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/users/me`, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+
+          if (!res.ok) throw new Error("지역 정보 fetch 에러");
+
+          const data = await res.json();
+          set({
+            selectedRegion: data.region || "서울 강남구",
+            isInitialized: true,
+          });
+        } catch (error) {
+          console.error("지역 정보 로드 실패:", error);
+          set({
+            selectedRegion: "서울 강남구",
+            isInitialized: true,
+          });
+        }
+      },
+    }),
+    {
+      name: "search-storage",
+      storage: {
+        getItem: (name) => {
+          const str = sessionStorage.getItem(name);
+          return str ? JSON.parse(str) : null;
+        },
+        setItem: (name, value) => {
+          sessionStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name) => {
+          sessionStorage.removeItem(name);
+        },
+      },
+    }
+  )
+);
+
+export default useRegionStore;


### PR DESCRIPTION
### 🔖 제목

- 메인페이지 헤더 로직 변경

---

### 📄 본문

- 메인페이지에서 설정하는 region 값을 유저정보에 저장 X, 전역관리하여 검색 필터링에 사용
- region 전역관리
- 여러 문제 개선
  - regionCode로 검색 안 됨 개선
    - regionCode를 제대로 저장하고 있지 못 함 => 백엔드 로직 개선 필요
  - RegionSelect - session 처리 부분 삭제
  - useRegion - getCurrentPostion 삭제

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    예:
    -   `Closes #161 `
    -   `Related to #161 `

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
