### PR TITLE
feat/게임 이름일 길면 레이아웃이 두 줄로 되도록 변경

### DIFF
--- a/boardgame-frontend/src/components/common/Card.tsx
+++ b/boardgame-frontend/src/components/common/Card.tsx
@@ -28,7 +28,7 @@ export default function Card({ id, location, title, currentMember, maxMember, ga
   const { month, day, weekday, hours, minutes } = dateFormatter(meetingDate);
   const dateFormat = `${month}/${day}(${weekday}) ${hours}:${minutes}`;
   return (
-    <article className="w-[335px] h-[116px] rounded-2xl p-4 bg-white">
+    <article className="w-[335px] py-4 rounded-2xl p-4 bg-white">
       <Link href={`/board/${id}`} className="flex flex-col gap-2">
         <div className="flex justify-between items-center gap-1">
           <div className="flex">
@@ -38,7 +38,7 @@ export default function Card({ id, location, title, currentMember, maxMember, ga
           <Badge>{dateFormat}</Badge>
         </div>
         <h2 className="font-medium text-[15px] text-[#161616]">{title}</h2>
-        <ul className="flex gap-1">
+        <ul className="flex gap-1 flex-wrap">
           <Badge>{`${currentMember}/${maxMember === 99 ? "무제한" : maxMember} 명`}</Badge>
           {Array.isArray(games) && games.map((game, index) => <Badge key={index}>{game}</Badge>)}
         </ul>


### PR DESCRIPTION
### 🔖 제목

feat/게임 이름일 길면 레이아웃이 두 줄로 되도록 변경

---

### 📄 본문

기존 뱃지 컴포넌트가 길면 위아래로 늘어나는 현상을 수정
새로운 레이아웃은 컴포넌트가 길면 두 줄로 바뀜

---


### ✅ 체크리스트

-   [✅] 코드가 정상적으로 동작합니다.
-   [✅] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [✅] 리뷰어를 지정했습니다.

