### PR TITLE
168 fix guest post list not loading

### DIFF
--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -15,12 +15,11 @@ import { useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import bottomLogo from "../../public/bottomLogo.svg";
 import plusIcon from "../../public/icons/ic_plus.svg";
-import { useAuthFetch } from "@/hooks/useAuthFetch";
 
 export default function Home() {
   const { ref, inView } = useInView({ threshold: 0 });
   const { data: session, status } = useSession();
-  const { authFetch } = useAuthFetch();
+
   const [postings, setPostings] = useState<Post[]>([]);
   const [page, setPage] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -34,8 +33,6 @@ export default function Home() {
   useEffect(() => {
     if (status === "authenticated" && session?.user?.accessToken) {
       initializeRegion(session.user.accessToken);
-    } else if (status === "unauthenticated") {
-      // 비로그인 상태면 기본값 사용 (이미 "서울 강남구"로 초기화됨)
     }
   }, [status, session?.user?.accessToken]);
 
@@ -45,8 +42,8 @@ export default function Home() {
       const { year, month, day } = dateFormatter(selectedDate.toISOString());
       const date = `${year}${month}${day}`;
 
-      const res = await authFetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}&regionCode=${selectedRegion}`
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}`
       );
 
       if (!res.ok) throw new Error("데이터 fetch 에러");
@@ -71,13 +68,13 @@ export default function Home() {
   }
 
   useEffect(() => {
-    if (isInitialized) {
+    if (isInitialized || status === "unauthenticated") {
       setPostings([]);
       setPage(0);
       setHasMore(true);
       getData(0);
     }
-  }, [selectedDate, selectedRegion]);
+  }, [selectedDate, selectedRegion, status, isInitialized]);
 
   useEffect(() => {
     if (inView && !isLoading && hasMore && page > 0) {

--- a/boardgame-frontend/src/app/page.tsx
+++ b/boardgame-frontend/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
       const date = `${year}${month}${day}`;
 
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}`
+        `${process.env.NEXT_PUBLIC_API_SERVER_HOST}/api/meetings?page=${pageNum}&size=15&date=${date}&regionCode=${selectedRegion}`
       );
 
       if (!res.ok) throw new Error("데이터 fetch 에러");

--- a/boardgame-frontend/src/stores/useRegionStore.ts
+++ b/boardgame-frontend/src/stores/useRegionStore.ts
@@ -1,4 +1,3 @@
-// stores/useRegionStore.ts
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -19,7 +18,6 @@ const useRegionStore = create<SearchStore>()(
       setSelectedRegion: (region: string) => {
         set({ selectedRegion: region });
       },
-
       initializeRegion: async (accessToken: string) => {
         // 이미 초기화됐으면 API 호출 안 함
         if (get().isInitialized) {
@@ -42,9 +40,6 @@ const useRegionStore = create<SearchStore>()(
           });
         } catch (error) {
           console.error("지역 정보 로드 실패:", error);
-          set({
-            selectedRegion: "서울 강남구",
-          });
         }
       },
     }),


### PR DESCRIPTION
### 🔖 제목

- 로그인하지 않은 상태에서 메인페이지 진입 시, 게시물 목록 조회 안됨 버그 수정

---

### 📄 본문

기존 코드
```
useEffect(() => {
    if (isInitialized) {
      setPostings([]);
      setPage(0);
      setHasMore(true);
      getData(0);
    }
  }, [selectedDate, selectedRegion]);
```
수정 후
```
useEffect(() => {
    if (isInitialized || status === "unauthenticated") {
      setPostings([]);
      setPage(0);
      setHasMore(true);
      getData(0);
    }
  }, [selectedDate, selectedRegion, status, isInitialized]);
```
- 게시물 목록 조회 조건 추가(status === " unauthenticated")
- 의존성 배열 추가 ( status, isInitialized )
  
시나리오 | 변경 감지 대상 | 조건 충족 | 결과
-- | -- | -- | --
로그인 초기 로드 | isInitialized: false → true | ```isInitialized === true``` | ✅
비로그인 초기 로드 | status: loading → unauthenticated | ```status === "unauthenticated"``` | ✅
날짜 변경 (로그인) | selectedDate | ```isInitialized === true``` | ✅
날짜 변경 (비로그인) | selectedDate | ```status === "unauthenticated"``` | ✅
지역 변경 (로그인) | selectedRegion | ```isInitialized === true``` | ✅

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    -   `Closes #168`
    -   `Related to #168`

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
