### PR TITLE
169 fix signup region rendering error

### DIFF
--- a/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
+++ b/boardgame-frontend/src/components/bottom-sheet/RegionSelect.tsx
@@ -31,7 +31,7 @@ export default function RegionSelect() {
   };
 
   const handleRegionSelect = (locationString: string) => {
-    setSelectedRegion(locationString.replace(/경기도/g, "경기")); // 전역 상태에 선택한 지역 저장
+    setSelectedRegion(locationString); // 전역 상태에 선택한 지역 저장
     setClose(); // 바텀시트 닫기
   };
 

--- a/boardgame-frontend/src/components/signup/LocationSearchResults.tsx
+++ b/boardgame-frontend/src/components/signup/LocationSearchResults.tsx
@@ -1,10 +1,4 @@
-import { LocationResult } from "@/types/location";
-
-interface LocationSearchResultsProps {
-  results: LocationResult[];
-  onSelect: (location: string) => void;
-  isLoading: boolean;
-}
+import { LocationSearchResultsProps } from "@/types/location";
 
 export default function LocationSearchResults({ results, onSelect, isLoading }: LocationSearchResultsProps) {
   if (isLoading) {
@@ -24,16 +18,14 @@ export default function LocationSearchResults({ results, onSelect, isLoading }: 
       <h3 className="text-xs">검색 결과</h3>
       <ul>
         {results.map((result, index) => {
-          const locationString = [result.region_1depth_name, result.region_2depth_name].filter(Boolean).join(" ");
-
           return (
             <li key={index} className="my-3 text-[#161616]">
               <button
                 type="button"
-                onClick={() => onSelect(locationString)}
+                onClick={() => onSelect(result)}
                 className="w-full text-left transition-colors cursor-pointer"
               >
-                {locationString}
+                {result}
               </button>
             </li>
           );

--- a/boardgame-frontend/src/types/location.ts
+++ b/boardgame-frontend/src/types/location.ts
@@ -1,8 +1,5 @@
-export interface LocationResult {
-  region_1depth_name: string; // "서울특별시"
-  region_2depth_name: string; // "강남구"
-}
-
-export interface LocationResponse {
-  documents: LocationResult[];
+export interface LocationSearchResultsProps {
+  results: String[];
+  onSelect: (location: String) => void;
+  isLoading: boolean;
 }


### PR DESCRIPTION
### 🔖 제목

# 회원가입 활동지역 검색 결과 타입 변경으로 인한 조회 버그 수정

---

### 📄 본문

- 문제 발생 원인
  1. 기존에는 검색 결과가 아래와 같은 객체 배열 형태였음
  
```
  results = {[{
      region_1depth_name: "경기 성남시",
      region_2depth_name: "수정구",
      },
  ]};
```
  
  2. 최근 API 응답 형태가 아래와 같이 문자열 배열 형태로 변경됨
  
```results = ["경기 성남시 수정구"];```

**=> 이로 인해 기존 타입 정의 및 가공 로직이 더 이상 맞지 않아 오류 발생**

---
### 수정내용
  - 활동지역 검색 결과 타입을 문자열 배열 기준으로 수정
  - 불필요해진 지역명 가공 로직 제거
  - 변경된 응답 구조에 맞게 타입 정의 및 사용처 정리

---

### 🔗 관련 이슈

-   관련된 이슈를 명시적으로 연결합니다.  
    -   `Closes #169 `
    -   `Related to #169 `

---

### ✅ 체크리스트

-   [x] 코드가 정상적으로 동작합니다.
-   [x] 변경 사항이 기존 기능에 영향을 주지 않습니다.
-   [x] 리뷰어를 지정했습니다.
-   [x] 관련 이슈를 연결했습니다.
